### PR TITLE
Add read config from package.json

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install parcel-plugin-svelte -D
 ```
 
 ## Configuration
-The default configuration should work for most people but I added the possibility to define your own config values any of through `svelte.config.js`(preferred method), `.svelterc`, or `svlete` field in `package.json`, for documentation on which parameters u can set and use look at the official [svelte docs](https://github.com/sveltejs/svelte)
+The default configuration should work for most people but I added the possibility to define your own config values any of through `svelte.config.js`(preferred method), `.svelterc`, or `svelte` field in `package.json`, for documentation on which parameters u can set and use look at the official [svelte docs](https://github.com/sveltejs/svelte)
 ```Javascript
 // Used by svelte.compile
 compilerOptions: {

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install parcel-plugin-svelte -D
 ```
 
 ## Configuration
-The default configuration should work for most people but I added the possibility to define your own config values either through `svelte.config.js`(preferred method) or `.svelterc`, for documentation on which parameters u can set and use look at the official [svelte docs](https://github.com/sveltejs/svelte)
+The default configuration should work for most people but I added the possibility to define your own config values any of through `svelte.config.js`(preferred method), `.svelterc`, or `svlete` field in `package.json`, for documentation on which parameters u can set and use look at the official [svelte docs](https://github.com/sveltejs/svelte)
 ```Javascript
 // Used by svelte.compile
 compilerOptions: {

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -16,9 +16,9 @@ class SvelteAsset extends JSAsset {
       preprocess: undefined
     };
 
-    const customConfig = await this.getConfig(['.svelterc', 'svelte.config.js']);
+    const customConfig = await this.getConfig(['.svelterc', 'svelte.config.js', 'package.json']);
     if (customConfig) {
-      svelteOptions = Object.assign(svelteOptions, customConfig);
+      svelteOptions = Object.assign(svelteOptions, customConfig.svelte || customConfig);
     }
 
     if (svelteOptions.preprocess) {


### PR DESCRIPTION
Implemented config loading from `svelte` field in package.json

```json
"svelte": {
  "compilerOptions": {
    ...
  }
},
```