### PR TITLE
Added optimizer and loss config parameters read

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parcel plugin to support svelte",
   "main": "./dist.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --timeout 50000",
+    "test": "NODE_ENV=test mocha --require babel-core/register --timeout 50000",
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -24,7 +24,7 @@ class SvelteAsset extends Asset {
       name: capitalize(sanitize(this.relativeName)) 
     };
 
-    const customConfig = (await this.getConfig(['.svelterc', 'svelte.config.js', 'package.json'])) || {};
+    let customConfig = (await this.getConfig(['.svelterc', 'svelte.config.js', 'package.json'])) || {};
     customConfig = customConfig.svelte || customConfig;
     if (customConfig.preprocess) {
       preprocessOptions = customConfig.preprocess;

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -20,7 +20,7 @@ class SvelteAsset extends Asset {
     const fixedCompilerOptions = {
       filename: this.relativeName,
       // the name of the constructor. Required for 'iife' and 'umd' output,
-	    // but otherwise mostly useful for debugging. Defaults to 'SvelteComponent'
+      // but otherwise mostly useful for debugging. Defaults to 'SvelteComponent'
       name: capitalize(sanitize(this.relativeName)) 
     };
 

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -29,14 +29,8 @@ class SvelteAsset extends Asset {
     if (customConfig.preprocess) {
       preprocessOptions = customConfig.preprocess;
     }
-    if (customConfig.compilerOptions) {
-      Object.keys(customConfig.compilerOptions).forEach(key => {
-        if (fixedCompilerOptions[key]) return;
-        compilerOptions[key] = customConfig.compilerOptions[key];
-      });
-    }
 
-    customConfig = Object.assign({}, compilerOptions, fixedCompilerOptions);
+    compilerOptions = Object.assign(compilerOptions, customConfig.compilerOptions || {}, fixedCompilerOptions);
 
     if (preprocessOptions) {
       const preprocessed = await preprocess(this.contents, preprocessOptions);
@@ -68,6 +62,12 @@ class SvelteAsset extends Asset {
     }
 
     return parts;
+  }
+
+  async postProcess(generated) {
+    // Hacky fix to remove duplicate JS asset (Css HMR code)
+    let filteredArr = generated.filter(part => part.type !== 'js');
+    return [generated[0]].concat(filteredArr);
   }
 }
 

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -24,21 +24,19 @@ class SvelteAsset extends Asset {
       name: capitalize(sanitize(this.relativeName)) 
     };
 
-    const customConfig = await this.getConfig(['.svelterc', 'svelte.config.js', 'package.json']);
-    if (customConfig) {
-      const customOptions = customConfig.svelte || customConfig;
-      if (customOptions.preprocess) {
-        preprocessOptions = customOptions.preprocess;
-      }
-      if (customOptions.compilerOptions) {
-        Object.keys(customOptions.compilerOptions).forEach(key => {
-          if (fixedCompilerOptions[key]) return;
-          compilerOptions[key] = customOptions.compilerOptions[key];
-        });
-      }
+    const customConfig = (await this.getConfig(['.svelterc', 'svelte.config.js', 'package.json'])) || {};
+    customConfig = customConfig.svelte || customConfig;
+    if (customConfig.preprocess) {
+      preprocessOptions = customConfig.preprocess;
+    }
+    if (customConfig.compilerOptions) {
+      Object.keys(customConfig.compilerOptions).forEach(key => {
+        if (fixedCompilerOptions[key]) return;
+        compilerOptions[key] = customConfig.compilerOptions[key];
+      });
     }
 
-    compilerOptions = Object.assign({}, compilerOptions, fixedCompilerOptions);
+    customConfig = Object.assign({}, compilerOptions, fixedCompilerOptions);
 
     if (preprocessOptions) {
       const preprocessed = await preprocess(this.contents, preprocessOptions);

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,4 +14,5 @@ function capitalize(str) {
 	return str[0].toUpperCase() + str.slice(1);
 }
 
-module.exports = { sanitize: sanitize, capitalize: capitalize }
+exports.sanitize = sanitize;
+exports.capitalize = capitalize;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+function sanitize(input) {
+	return path
+		.basename(input)
+		.replace(path.extname(input), '')
+		.replace(/[^a-zA-Z_$0-9]+/g, '_')
+		.replace(/^_/, '')
+		.replace(/_$/, '')
+		.replace(/^(\d)/, '_$1');
+}
+
+function capitalize(str) {
+	return str[0].toUpperCase() + str.slice(1);
+}
+
+module.exports = { sanitize: sanitize, capitalize: capitalize }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,16 @@
 const path = require('path');
 
 function sanitize(input) {
-	return path
-		.basename(input)
-		.replace(path.extname(input), '')
-		.replace(/[^a-zA-Z_$0-9]+/g, '_')
-		.replace(/^_/, '')
-		.replace(/_$/, '')
-		.replace(/^(\d)/, '_$1');
+  return path.basename(input)
+	     .replace(path.extname(input), '')
+	     .replace(/[^a-zA-Z_$0-9]+/g, '_')
+	     .replace(/^_/, '')
+	     .replace(/_$/, '')
+	     .replace(/^(\d)/, '_$1');
 }
 
 function capitalize(str) {
-	return str[0].toUpperCase() + str.slice(1);
+  return str[0].toUpperCase() + str.slice(1);
 }
 
 exports.sanitize = sanitize;

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [["env", {
+    "targets": {
+      "node": "current"
+    }
+  }]],
+  "ignore": ["integration"]
+}

--- a/test/Integration/WithConfig/AppWithConfig.svelte
+++ b/test/Integration/WithConfig/AppWithConfig.svelte
@@ -1,0 +1,1 @@
+<h1>Hello __REPLACE_ME__</h1>

--- a/test/Integration/WithConfig/run.js
+++ b/test/Integration/WithConfig/run.js
@@ -1,0 +1,5 @@
+import App from './AppWithConfig.svelte';
+
+new App({
+    target: document.getElementById("app"),
+});

--- a/test/Integration/WithConfig/svelte.config.js
+++ b/test/Integration/WithConfig/svelte.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  compilerOptions: {
+    format: 'es'
+  },
+  preprocess: {
+    markup: ({ content }) => {
+
+      content = content.replace('__REPLACE_ME__', 'world');
+
+      return {
+        code: content
+      };
+    },
+  },
+};

--- a/test/with_config.js
+++ b/test/with_config.js
@@ -1,0 +1,27 @@
+const { setupBundler, run } = require('./utils');
+const assertBundleTree = require('parcel-assert-bundle-tree');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
+
+describe('with config', function() {
+  it('Should create a basic svelte bundle with config files', async function() {
+    const bundler = await setupBundler(path.join(__dirname, './Integration/WithConfig/run.js'));
+    const bundle = await bundler.bundle();
+
+    assertBundleTree(bundle, {
+      type: 'js',
+      assets: ['run.js', 'AppWithConfig.svelte'],
+      childBundles: [
+        {
+          type: 'map'
+        }
+      ]
+    });
+
+    let file = fs.readFileSync(__dirname + '/dist/run.js', 'utf8');
+    assert(file.includes('function AppWithConfig'));
+    assert(file.indexOf('__REPLACE_ME__') === -1);
+    assert(file.indexOf('Hello world') !== -1);
+  });
+});


### PR DESCRIPTION
In my PR:
- Fix `{ filename: this.relativeName , ...}` in svelteOptions will be lost if we override default config
- Add missing compiler option `name` (for iife and umd format)
- Override compiler object's property instead of override compiler object

<br><br><br><br>


`Note`: Sorry for my poor English