### PR TITLE
Adds HMR support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mocha": "^5.1.1",
     "parcel-assert-bundle-tree": "^1.0.0",
     "parcel-bundler": "^1.7.1",
-    "svelte": "^2.4.2"
+    "svelte": "^2.4.2",
+    "svelte-dev-helper": "^1.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "parcel-assert-bundle-tree": "^1.0.0",
     "parcel-bundler": "^1.7.1",
     "svelte": "^2.4.2",
-    "svelte-dev-helper": "^1.1.7"
+    "svelte-dev-helper": "^1.1.7",
+    "parcel-plugin-svelte": "."
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "parcel-bundler": "^1.7.1",
     "svelte": "^2.4.2",
     "svelte-dev-helper": "^1.1.7",
-    "parcel-plugin-svelte": "."
+    "parcel-plugin-svelte": "file:."
   }
 }

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -2,11 +2,7 @@ const { compile, preprocess } = require('svelte');
 const { Asset } = require('./ParcelAdapter');
 const { sanitize, capitalize } = require('./utils');
 
-
-const hotApi = require.resolve('./hot-api');
-
-function makeHot(id, code, hotOptions) {
-  const options = JSON.stringify(hotOptions);
+function makeHot(id, code) {
   const replacement = `
 if (module.hot) {
   const { configure, register, reload } = require('parcel-plugin-svelte/lib/hot-api');
@@ -15,7 +11,7 @@ if (module.hot) {
 
   if (!module.hot.data) {
     // initial load
-    configure(${options});
+    configure({});
     $2 = register('${id}', $2);
   } else {
     // hot update

--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -3,6 +3,8 @@ const { Asset } = require('./ParcelAdapter');
 const { sanitize, capitalize } = require('./utils');
 
 
+const hotApi = require.resolve('./hot-api');
+
 function makeHot(id, code, hotOptions) {
   const options = JSON.stringify(hotOptions);
   const replacement = `
@@ -64,7 +66,11 @@ class SvelteAsset extends Asset {
 
     let { css, js } = compile(this.contents, compilerOptions);
     let { map,code } = js;
-    code = makeHot(fixedCompilerOptions.filename, code);
+
+    if (process.env.NODE_ENV !== 'production') {
+      code = makeHot(fixedCompilerOptions.filename, code);
+    }
+
     css = css.code;
 
     if (this.options.sourceMaps) {

--- a/src/hot-api.js
+++ b/src/hot-api.js
@@ -1,0 +1,51 @@
+import { Registry, configure as configureProxy, createProxy } from 'svelte-dev-helper';
+
+let hotOptions = {
+  noPreserveState: false
+};
+
+export function configure(options) {
+  hotOptions = Object.assign(hotOptions, options);
+  configureProxy(hotOptions);
+}
+
+export function register(id, component) {
+
+  //store original component in registry
+  Registry.set(id, {
+    rollback: null,
+    component,
+    instances: []
+  });
+
+  //create the proxy itself
+  const proxy = createProxy(id);
+
+  //patch the registry record with proxy constructor
+  const record = Registry.get(id);
+  record.proxy = proxy;
+  Registry.set(id, record);
+
+  return proxy;
+}
+
+export function reload(id, component) {
+
+  const record = Registry.get(id);
+
+  //keep reference to previous version to enable rollback
+  record.rollback = record.component;
+
+  //replace component in registry with newly loaded component
+  record.component = component;
+
+  Registry.set(id, record);
+
+  //re-render the proxy instances
+  record.instances.slice().forEach(function (instance) {
+    instance && instance._rerender();
+  });
+
+  //return the original proxy constructor that was `register()`-ed
+  return record.proxy;
+}


### PR DESCRIPTION
This PR adds full HMR support to this plugin.

However @DeMoorJasper, I cannot make the tests pass on node 6.

I have tried with `require.resolve()` like we did it [here](https://github.com/sveltejs/svelte-loader/blob/master/index.js#L6-L12). 
But then it cannot resolve absolute paths at all. And even HMR does not work.

Right now HMR works perfectly, but the tests fail.

Not too familiar with parcel, hope you can help in this regard.