### PR TITLE
fix relative path on windows

### DIFF
--- a/src/SvelteAsset.js
+++ b/src/SvelteAsset.js
@@ -4,7 +4,7 @@ const { sanitize, capitalize } = require('./utils');
 const path = require('path');
 
 function makeHot(id, code, asset) {
-  const hotApiRequire = path.relative(path.dirname(asset.name), require.resolve('./hot-api')).replace(/\\/, '/');
+  const hotApiRequire = path.relative(path.dirname(asset.name), require.resolve('./hot-api')).replace(/\\/g, '/');
 
   const replacement = `
     if (module.hot) {


### PR DESCRIPTION
Hi @DeMoorJasper,

I'm a parcel user on windows. I saw that you fixed the bug on windows but it seems like you missing global flag in regexp.

After i fix it it seems to work normally. One thing i not sure is that why the bug is not happen on `parcel build` but only on `parcel serve`. May be that's why your test missed it!

Hope that you soon deploy it. And again, thank for creating such wonderful app!

Sincerely!