### PR TITLE
Make css: true for defautl

### DIFF
--- a/src/svelte-asset.js
+++ b/src/svelte-asset.js
@@ -39,7 +39,7 @@ class SvelteAsset extends Asset {
       generate: 'dom',
       format: 'cjs',
       store: true,
-      css: false
+      css: true
     };
     let preprocessOptions;
 


### PR DESCRIPTION
Inline styles are a pretty core principle of Svelte - therefore I genuinely believe this should be true by default. Otherwise, HMR causes the styles to disappear every time you edit the code.