### PR TITLE
Minor fixes for v3

### DIFF
--- a/packages/parcel-plugin-svelte/src/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/src/svelte-asset.js
@@ -45,19 +45,25 @@ class SvelteAsset extends Asset {
 
     let defaultOptions = {
       generate: 'dom',
-      store: true,
-      css: true,
-      format: major_version >= 3 ? 'esm' : 'es'
+      css: true
     };
 
     let customCompilerOptions = config.compilerOptions || {};
+
+    if (major_version >= 3) {
+      defaultOptions.format = 'esm';
+      defaultOptions.sveltePath = 'svelte';
+    } else {
+      defaultOptions.format = 'es';
+      defaultOptions.store = true;
+      defaultOptions.shared = 'svelte/shared.js';
+    }
 
     let fixedCompilerOptions = {
       filename: this.relativeName,
       // The name of the constructor. Required for 'iife' and 'umd' output,
       // but otherwise mostly useful for debugging. Defaults to 'SvelteComponent'
-      name: capitalize(sanitize(this.relativeName)),
-      shared: customCompilerOptions.shared || major_version >= 3 ? 'svelte/internal.js' : 'svelte/shared.js'
+      name: capitalize(sanitize(this.relativeName))
     };
 
     config.compilerOptions = Object.assign({}, defaultOptions, customCompilerOptions, fixedCompilerOptions);


### PR DESCRIPTION
This commit fixes the build options for v2 and for v3. As I understand it:

- store is no longer an option, it is enabled by default in v2, and the way stores work has changed in v3.
- shared is no longer supported, instead the path to `svelte` is passed to the compiler.

I've also moved the v2/v3 logic into a single place, I can clean this up more once we get it working.