### PR TITLE
Fix: sanitize a loading configuration

### DIFF
--- a/packages/parcel-plugin-svelte/src/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/src/svelte-asset.js
@@ -42,6 +42,12 @@ class SvelteAsset extends Asset {
   async getConfig() {
     let config = (await super.getConfig(['.svelterc', 'svelte.config.js', 'package.json'])) || {};
     config = config.svelte || config;
+    
+    // If somebody use svelte field as a path to unprocessed sources
+    // @see https://github.com/rollup/rollup-plugin-svelte#pkgsvelte
+    if (config == null || typeof config !== "object") {
+      config = {};
+    }
 
     let defaultOptions = {
       generate: 'dom',


### PR DESCRIPTION
If you try to load a module with svelte components, which contains [`svelte` field as a relative path to unprocessed source file](https://github.com/rollup/rollup-plugin-svelte#pkgsvelte) you will get a error:

```
./webapp/node_modules/svelte-routing/src/Route.svelte: Cannot create property 'compilerOptions' on string 'src/index.js'
    at SvelteAsset.getConfig (./webapp/node_modules/parcel-plugin-svelte/src/svelte-asset.js:71:28)
    at async SvelteAsset.generate (./webapp/node_modules/parcel-plugin-svelte/src/svelte-asset.js:77:18)
    at async SvelteAsset.process (./webapp/node_modules/parcel-bundler/src/Asset.js:216:24)
    at async Pipeline.processAsset (./webapp/node_modules/parcel-bundler/src/Pipeline.js:46:7)
    at async Pipeline.process (./webapp/node_modules/parcel-bundler/src/Pipeline.js:24:23)
    at async Object.run (./webapp/node_modules/parcel-bundler/src/worker.js:15:12)
    at async Bundler.loadAsset (./webapp/node_modules/parcel-bundler/src/Bundler.js:577:19)
    at async ./webapp/node_modules/parcel-bundler/src/Bundler.js:610:13
    at async Promise.all (index 4)
    at async Bundler.loadAsset (./webapp/node_modules/parcel-bundler/src/Bundler.js:599:21)
```

I suggest to sanitize this case... Or maybe we need to remove `package.json` from loading config?