### PR TITLE
Fix: add config options to preprocess

### DIFF
--- a/packages/parcel-plugin-svelte/src/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/src/svelte-asset.js
@@ -82,7 +82,7 @@ class SvelteAsset extends Asset {
     let compilerOptions = config.compilerOptions;
 
     if (config.preprocess) {
-      const preprocessed = await preprocess(this.contents, config.preprocess);
+      const preprocessed = await preprocess(this.contents, config.preprocess, config.compilerOptions);
       this.contents = preprocessed.toString();
     }
 


### PR DESCRIPTION
I tried to use [typescript preprocessor](https://github.com/kaisermann/svelte-preprocess) and I got this error:

```
The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:125:11)
    at dirname (path.js:1260:5)
    at module.exports (/Users/vladislav/dev/island/src/webapp/node_modules/svelte-preprocess/src/transformers/typescript.js:157:54)
    at script (/Users/vladislav/dev/island/src/webapp/node_modules/svelte-preprocess/src/processors/typescript.js:14:31)
```

The problem is the lack of options when calling preprocess.
