### PR TITLE
fix: temporary fix for #49

### DIFF
--- a/packages/parcel-plugin-svelte/src/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/src/svelte-asset.js
@@ -42,10 +42,10 @@ class SvelteAsset extends Asset {
   async getConfig() {
     let config = (await super.getConfig(['.svelterc', 'svelte.config.js', 'package.json'])) || {};
     config = config.svelte || config;
-    
+
     // If somebody use svelte field as a path to unprocessed sources
     // @see https://github.com/rollup/rollup-plugin-svelte#pkgsvelte
-    if (config == null || typeof config !== "object") {
+    if (config == null || typeof config !== 'object') {
       config = {};
     }
 
@@ -89,7 +89,8 @@ class SvelteAsset extends Asset {
     let { css, js } = compile(this.contents, compilerOptions);
     let { map, code } = js;
 
-    if (process.env.NODE_ENV !== 'production' && this.options.hmr) {
+    // Enable HMR only on svelte 2.x or below
+    if (this.options.hmr && major_version < 3) {
       code = makeHot(compilerOptions.filename, code, this);
     }
 


### PR DESCRIPTION
Currently, Svelte 3 has some issues with HMR, so as a temporary solution I disabled it if the version of Svelte is `>=` to 3.

This should be changed when HMR support is ready. I followed some issues on the matter and hopefully, I'll update it when its time.