### PR TITLE
Fix preprocessors in config files

### DIFF
--- a/packages/parcel-plugin-svelte/lib/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/lib/svelte-asset.js
@@ -22,12 +22,13 @@ class SvelteAsset extends Asset {
     // Note: "compilerOptions" is deprecated and replaced by compiler.
     // Since the depracation didnt take effect yet, we still support the old way.
     const compiler = { ...customOptions.compilerOptions, ...customOptions.compiler, ...parcelCompilerOptions };
+    const preprocess = customOptions.preprocess
 
     return { compiler, preprocess };
   }
 
   async generate() {
-    const config = this.getConfig();
+    const config = await this.getConfig();
 
     if (config.preprocess) {
       const preprocessed = await preprocess(this.contents, config.preprocess, config.compiler);


### PR DESCRIPTION
These two bugs prevented the `preprocess` option from actually being used. The first bug was accidentally using the preprocess function as an argument to itself. The second bug was not awaiting `getConfig`, which is async.