### PR TITLE
fix: generateName doesn't return the generated module name

### DIFF
--- a/packages/parcel-plugin-svelte/lib/utils.js
+++ b/packages/parcel-plugin-svelte/lib/utils.js
@@ -10,6 +10,7 @@ function generateName(input) {
     .replace(/^(\d)/, '_$1');
 
   name = name[0].toUpperCase() + name.slice(1);
+  return name;
 }
 
 function makeHot(id, code, asset) {


### PR DESCRIPTION
The `name` field passed to compiler [here](https://github.com/DeMoorJasper/parcel-plugin-svelte/blob/c9273c3b091be5b7b36b4791a6912b8c28fa515a/packages/parcel-plugin-svelte/lib/svelte-asset.js#L16) is always undefined.