### PR TITLE
Pass preprocessor dependencies to parcel watcher

### DIFF
--- a/packages/parcel-plugin-svelte/lib/svelte-asset.js
+++ b/packages/parcel-plugin-svelte/lib/svelte-asset.js
@@ -32,6 +32,11 @@ class SvelteAsset extends Asset {
 
     if (config.preprocess) {
       const preprocessed = await preprocess(this.contents, config.preprocess, { filename: config.compiler.filename });
+      if (preprocessed.dependencies) {
+        for (const dependency of preprocessed.dependencies) {
+          this.addDependency(dependency, { includedInParent: true });
+        }
+      }
       this.contents = preprocessed.toString();
     }
 


### PR DESCRIPTION
This PR makes the plugin pass the `dependencies` array returned by the svelte preprocessor step to the parcel dependency table.

Related to https://github.com/kaisermann/svelte-preprocess/issues/111