### PR TITLE
Added Svelte to the dependancies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,16 +8,8 @@ A parcel plugin that enables svelte support
 
 ### Install dependencies
 
-Install Svelte as a dependancy for the project
-
 ```bash
-yarn add svelte
-```
-
-Next install the Dev dependacies you need to Svelte & Parcel 
-
-```bash
-yarn add parcel-bundler parcel-plugin-svelte @babel/polyfill -D
+yarn add svelte parcel-bundler parcel-plugin-svelte @babel/polyfill -D
 ```
 
 ### Update the package.json

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,14 @@ A parcel plugin that enables svelte support
 
 ### Install dependencies
 
+Install Svelte as a dependancy for the project
+
+```bash
+yarn add svelte
+```
+
+Next install the Dev dependacies you need to Svelte & Parcel 
+
 ```bash
 yarn add parcel-bundler parcel-plugin-svelte @babel/polyfill -D
 ```


### PR DESCRIPTION
When I cloned this project and installed the dependencies, I then added the files from the `README.MD` file, but I was unable to get this project to work without installing Svelte as a normal dependency. I updated the the `README.MD`  with instructions on how to add Svelte as a dependency.

This PR is a fix for issue #140, I tried to keep the look consistent for the README.

Thanks so much, have a great day 😄 👍  